### PR TITLE
SUPESC-52 added Quote.name transfer property definition.

### DIFF
--- a/src/Spryker/Shared/CartsRestApi/Transfer/carts_rest_api.transfer.xml
+++ b/src/Spryker/Shared/CartsRestApi/Transfer/carts_rest_api.transfer.xml
@@ -84,6 +84,7 @@
         <property name="uuid" type="string" />
         <property name="customerReference" type="string" />
         <property name="companyUserId" type="int" />
+        <property name="name" type="string" />
     </transfer>
 
     <transfer name="QuoteUpdateRequestAttributes">


### PR DESCRIPTION
Branch: backport/supesc-52/carts-rest-api-3.1.2
Ticket: https://spryker.atlassian.net/browse/SUPESC-52
Target Version: 3.2.0
RG: https://release.spryker.com/release-groups/view/1586

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CartsRestApi           | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module CartsRestApi

##### Change log

Fixes

- Introduced `Quote.name` transfer property.
